### PR TITLE
Updating php[tek] 2017

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ ConFoo is a multi-technology conference aimed specifically at web developers. Th
 * [Midwest PHP](https://2017.midwestphp.org/) : March 17 - 18, 2017 : Bloomington, MN US
 We’re pleased to announce our conference, Midwest PHP should be one of the best PHP conferences where community members from around the world come together to learn and share information about the latest trends and technologies in professional PHP development.
 
-* [php\[tek\]](https://tek.phparch.com/) : May 24-26, 2017 : Atlanta, GA US
+* [php&#91;tek&#93;](https://tek.phparch.com/) : May 24-26, 2017 : Atlanta, GA US
 The premier PHP conference and annual homecoming for the PHP Community. This conference will be the 12th annual edition, and php[architect] and One for All Events are excited to bring it to Atlanta, the empire city of the south!
 
 * [Northeast PHP](http://northeastphp.org/) : August 9 to 11, 2017 : Charlottetown, PEI, Canada

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ ConFoo is a multi-technology conference aimed specifically at web developers. Th
 * [Midwest PHP](https://2017.midwestphp.org/) : March 17 - 18, 2017 : Bloomington, MN US
 We’re pleased to announce our conference, Midwest PHP should be one of the best PHP conferences where community members from around the world come together to learn and share information about the latest trends and technologies in professional PHP development.
 
-* [php tek](https://tek.phparch.com/) : May 24-26, 2017 : Atlanta, GA US
+* [php\[tek\]](https://tek.phparch.com/) : May 24-26, 2017 : Atlanta, GA US
 The premier PHP conference and annual homecoming for the PHP Community. This conference will be the 12th annual edition, and php[architect] and One for All Events are excited to bring it to Atlanta, the empire city of the south!
 
 * [Northeast PHP](http://northeastphp.org/) : August 9 to 11, 2017 : Charlottetown, PEI, Canada


### PR DESCRIPTION
Fixed the improper naming of the conference.  (IE:  Got the []'s to show up)