### PR TITLE
Add info about Midwest PHP 2018

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ This page list all known PHP and PHP related conferences. If we have missed one,
 * [ZendCon](http://zendcon.com) : October 23-26, 2017 : Las Vegas, NV US
 With over 250 million PHP applications driven by a global community of more than 5 million active developers and 100% of enterprises adopting open source software, ZendCon 2017 brings you a curated selection of the best experts, training, and networking opportunities to embrace this vast ecosystem. In its 13th year, ZendCon offers authoritative sessions, in-depth technical tutorials, exhibit hall activities, and informal opportunities to spotlight the best in enterprise PHP and open source development, focusing on the latest for PHP 7, the evolution of frameworks and tools, API excellence, and innovations on many open source technologies related to the web.
 
+* [Midwest PHP 2018](https://2018.midwestphp.org/) : March 9-10, 2018 : Bloomington, MN US
+Midwest PHP is the FUN conference. This is our fifth annual conference, and each year it gets better and better. Our goal is to share best practices, ideas, and techniques about building state-of-the-art software applications.
+
+The conference is at the Radisson Blu Mall of America. We can't think of a better place to connect with friends, old and new, than in a relaxed environment with entertainment at your front door, and inspiring talks from people doing amazing things.
+
 ## South America
 * [PHP Conference Brazil](http://www.phpconference.com.br) : December 6 - 10, 2017 : Osasco, SP, Brazil
 Reaching it's 12th edition, PHP Conference Brazil is known as the Main PHP Event in Latin America, having reached more than 7,000 participants and more than 400h of PHP content throughout it's history.

--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@ This page list all known PHP and PHP related conferences. If we have missed one,
 With over 250 million PHP applications driven by a global community of more than 5 million active developers and 100% of enterprises adopting open source software, ZendCon 2017 brings you a curated selection of the best experts, training, and networking opportunities to embrace this vast ecosystem. In its 13th year, ZendCon offers authoritative sessions, in-depth technical tutorials, exhibit hall activities, and informal opportunities to spotlight the best in enterprise PHP and open source development, focusing on the latest for PHP 7, the evolution of frameworks and tools, API excellence, and innovations on many open source technologies related to the web.
 
 * [Midwest PHP 2018](https://2018.midwestphp.org/) : March 9-10, 2018 : Bloomington, MN US
-Midwest PHP is the FUN conference. This is our fifth annual conference, and each year it gets better and better. Our goal is to share best practices, ideas, and techniques about building state-of-the-art software applications.
 
-The conference is at the Radisson Blu Mall of America. We can't think of a better place to connect with friends, old and new, than in a relaxed environment with entertainment at your front door, and inspiring talks from people doing amazing things.
+  Midwest PHP is the FUN conference. This is our fifth annual conference, and each year it gets better and better. Our goal is to share best practices, ideas, and techniques about building state-of-the-art software applications.
+
+  The conference is at the Radisson Blu Mall of America. We can't think of a better place to connect with friends, old and new, than in a relaxed environment with entertainment at your front door, and inspiring talks from people doing amazing things.
 
 ## South America
 * [PHP Conference Brazil](http://www.phpconference.com.br) : December 6 - 10, 2017 : Osasco, SP, Brazil


### PR DESCRIPTION
Pull directly from the conference web site.