### PR TITLE
Add info about the 2018 Longhorn PHP Conference

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ This page list all known PHP and PHP related conferences. If we have missed one,
 * [ZendCon](http://zendcon.com) : October 23-26, 2017 : Las Vegas, NV US
 With over 250 million PHP applications driven by a global community of more than 5 million active developers and 100% of enterprises adopting open source software, ZendCon 2017 brings you a curated selection of the best experts, training, and networking opportunities to embrace this vast ecosystem. In its 13th year, ZendCon offers authoritative sessions, in-depth technical tutorials, exhibit hall activities, and informal opportunities to spotlight the best in enterprise PHP and open source development, focusing on the latest for PHP 7, the evolution of frameworks and tools, API excellence, and innovations on many open source technologies related to the web.
 
+* [Longhorn PHP Conference](https://www.longhornphp.com/) : April 19-21, 2018 : Austin, TX US
+Our main goal as a conference is to equip attendees to be better developers. If you work with developers or alongside developers, we’ll showcase tools and techniques to level up your ability to solve the problems you face every day.
+
+You’ll get to learn from and alongside a diverse group of developers from all over the region, country, and even the globe. Whether you’re a junior developer or an experienced programmer, you’ll be learning alongside your peers.
+
+You’ll get direct access to experts in all aspects of modern web development: security, programming techniques, devops, architecture, database administration, and more.
+
 ## South America
 * [PHP Conference Brazil](http://www.phpconference.com.br) : December 6 - 10, 2017 : Osasco, SP, Brazil
 Reaching it's 12th edition, PHP Conference Brazil is known as the Main PHP Event in Latin America, having reached more than 7,000 participants and more than 400h of PHP content throughout it's history.


### PR DESCRIPTION
The blurb was pulled from their "about" page.